### PR TITLE
Start logging time for render and message display

### DIFF
--- a/gist/src/main/java/build/gist/presentation/GistModalActivity.kt
+++ b/gist/src/main/java/build/gist/presentation/GistModalActivity.kt
@@ -15,6 +15,7 @@ import build.gist.data.model.GistMessageProperties
 import build.gist.data.model.Message
 import build.gist.data.model.MessagePosition
 import build.gist.databinding.ActivityGistBinding
+import build.gist.utilities.ElapsedTimer
 import com.google.gson.Gson
 
 const val GIST_MESSAGE_INTENT: String = "GIST_MESSAGE"
@@ -24,6 +25,7 @@ class GistModalActivity : AppCompatActivity(), GistListener, GistViewListener {
     private lateinit var binding: ActivityGistBinding
     private var currentMessage: Message? = null
     private var messagePosition: MessagePosition = MessagePosition.CENTER
+    private var elapsedTimer: ElapsedTimer = ElapsedTimer()
 
     companion object {
         fun newIntent(context: Context): Intent {
@@ -42,6 +44,7 @@ class GistModalActivity : AppCompatActivity(), GistListener, GistViewListener {
         Gson().fromJson(messageStr, Message::class.java)?.let { messageObj ->
             currentMessage = messageObj
             currentMessage?.let { message ->
+                elapsedTimer.start("Displaying modal for message: ${message.messageId}")
                 binding.gistView.listener = this
                 binding.gistView.setup(message)
                 messagePosition = if (modalPositionStr == null) {
@@ -103,6 +106,9 @@ class GistModalActivity : AppCompatActivity(), GistListener, GistViewListener {
             }
             animation.setTarget(binding.modalGistViewLayout)
             animation.start()
+            animation.doOnEnd {
+                elapsedTimer.end()
+            }
         }
     }
 

--- a/gist/src/main/java/build/gist/presentation/engine/EngineWebView.kt
+++ b/gist/src/main/java/build/gist/presentation/engine/EngineWebView.kt
@@ -13,6 +13,7 @@ import build.gist.BuildConfig
 import build.gist.data.model.engine.EngineWebConfiguration
 import build.gist.presentation.GIST_TAG
 import build.gist.presentation.GistSdk
+import build.gist.utilities.ElapsedTimer
 import com.google.gson.Gson
 import java.io.UnsupportedEncodingException
 import java.util.*
@@ -26,6 +27,7 @@ internal class EngineWebView @JvmOverloads constructor(
     private var timer: Timer? = null
     private var timerTask: TimerTask? = null
     private var webView: WebView = WebView(context)
+    private var elapsedTimer: ElapsedTimer = ElapsedTimer()
 
     init {
         this.addView(webView)
@@ -36,6 +38,7 @@ internal class EngineWebView @JvmOverloads constructor(
         setupTimeout()
         val jsonString = Gson().toJson(configuration)
         encodeToBase64(jsonString)?.let { options ->
+            elapsedTimer.start("Engine render for message: ${configuration.messageId}")
             val messageUrl = "${GistSdk.gistEnvironment.getGistRendererUrl()}/index.html?options=${options}"
             Log.i(GIST_TAG, "Rendering message with URL: $messageUrl")
             webView.loadUrl(messageUrl)
@@ -112,6 +115,7 @@ internal class EngineWebView @JvmOverloads constructor(
     }
 
     override fun routeChanged(newRoute: String) {
+        elapsedTimer.start("Engine render for message: $newRoute")
         listener?.routeChanged(newRoute)
     }
 
@@ -120,6 +124,7 @@ internal class EngineWebView @JvmOverloads constructor(
     }
 
     override fun routeLoaded(route: String) {
+        elapsedTimer.end()
         listener?.routeLoaded(route)
     }
 

--- a/gist/src/main/java/build/gist/utilities/ElapsedTimer.kt
+++ b/gist/src/main/java/build/gist/utilities/ElapsedTimer.kt
@@ -1,0 +1,22 @@
+package build.gist.utilities
+
+import android.util.Log
+import build.gist.presentation.GIST_TAG
+
+class ElapsedTimer {
+    private var title: String = ""
+    private var startTime: Long = 0
+
+    fun start(title: String) {
+        this.title = title
+        this.startTime = System.currentTimeMillis()
+    }
+
+    fun end() {
+        if (startTime > 0) {
+            val timeElapsed = (System.currentTimeMillis() - startTime) / 1000.0
+            Log.d(GIST_TAG, "$title timer elapsed in $timeElapsed seconds")
+            startTime = 0
+        }
+    }
+}


### PR DESCRIPTION
As part of the rendering performance updates we need to start measuring the time it takes to render a message.

Part of: https://github.com/customerio/issues/issues/9268