### PR TITLE
update encoding to cater android lower API

### DIFF
--- a/gist/build.gradle
+++ b/gist/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 31
     buildToolsVersion "30.0.2"
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/gist/build.gradle
+++ b/gist/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.2"
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 30
+        minSdkVersion 21
+        targetSdkVersion 31
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'


### PR DESCRIPTION
The minimum Android API level CIO SDK supports is 21 and the minimum Gist SDK supports is 19. 

The class used for encoding was available on Android 26 and above. This PR updates the class to another class available in lower API.

closes: https://github.com/customerio/customerio-android/issues/199