### PR TITLE
Reverts persistent system actions behaviour

### DIFF
--- a/gist/src/main/java/build/gist/presentation/GistView.kt
+++ b/gist/src/main/java/build/gist/presentation/GistView.kt
@@ -99,13 +99,8 @@ class GistView @JvmOverloads constructor(
                     system -> {
                         try {
                             shouldLogAction = false
-                            val gistProperties = GistMessageProperties.getGistProperties(message)
-                            if (gistProperties.persistent) {
-                                Log.i(GIST_TAG, "Message is persistent, not dismissing.")
-                            } else {
-                                Log.i(GIST_TAG, "Dismissing from system action: $action")
-                                GistSdk.handleGistClosed(message)
-                            }
+                            Log.i(GIST_TAG, "Dismissing from system action: $action")
+                            GistSdk.handleGistClosed(message)
                             val intent = Intent(Intent.ACTION_VIEW)
                             intent.data = Uri.parse(action)
                             intent.flags =


### PR DESCRIPTION
After our sync call yesterday I realized that not dismissing a message after a "system action" is a terrible idea as it would keep the message active if a deep link is performed on the same app.

This reverts the behavior back to dismissing the message and keeping it in the queue until actually dismissed.