### PR TITLE
Fixes an issue when handling HTTP Code 304

### DIFF
--- a/gist/src/main/java/build/gist/data/listeners/Queue.kt
+++ b/gist/src/main/java/build/gist/data/listeners/Queue.kt
@@ -72,6 +72,9 @@ class Queue : GistListener {
             try {
                 Log.i(GIST_TAG, "Fetching user messages")
                 val latestMessagesResponse = gistQueueService.fetchMessagesForUser()
+                // If there's no change (304), move on.
+                if (latestMessagesResponse.code() == 304) { return@launch }
+
                 // To prevent us from showing expired / revoked messages, clear user messages from local queue.
                 clearUserMessagesFromLocalStore()
                 if (latestMessagesResponse.code() == 204) {


### PR DESCRIPTION
The queue service will start returning 304 when content hasn't been updated. This fixes an issue when the local queue is being cleared when no content is returned.

Part of: https://github.com/customerio/issues/issues/10139